### PR TITLE
New line-length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gist-box",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gist-box",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A helper class for updating a single-file Gist",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export interface Updates {
 /**
  * The maximum number of characters in a pinned Gist line
  */
-export const MAX_LENGTH = 46
+export const MAX_LENGTH = 63
 /**
  * The maximum number of lines in a pinned Gist
  */


### PR DESCRIPTION
The GitHub profile page recently changed widths, so now the maximum line-length for pinned Gists has increased from `46` to `63`!