### PR TITLE
Update MAX_WIDTH

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,9 @@ export interface Updates {
 
 /**
  * The maximum number of characters in a pinned Gist line
+ * Note: This number varies across different fonts
  */
-export const MAX_LENGTH = 48
+export const MAX_LENGTH = 63
 /**
  * The maximum number of lines in a pinned Gist
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export const MAX_LINES = 5
 /**
  * The maximum width of a pinned Gist image
  */
-export const MAX_WIDTH = 325
+export const MAX_WIDTH = 378
 /**
  * The maximum height of a pinned Gist image
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export interface Updates {
 /**
  * The maximum number of characters in a pinned Gist line
  */
-export const MAX_LENGTH = 63
+export const MAX_LENGTH = 48
 /**
  * The maximum number of lines in a pinned Gist
  */


### PR DESCRIPTION
Due to GitHub's design update, `MAX_WIDTH` is increased.

And add a note to `MAX_LENGTH`.